### PR TITLE
Prevent UI Crash

### DIFF
--- a/Sources/LegacyScrollView/Proxy/LegacyScrollViewProxy.swift
+++ b/Sources/LegacyScrollView/Proxy/LegacyScrollViewProxy.swift
@@ -10,14 +10,14 @@ import SwiftUI
 
 public struct LegacyScrollViewProxy {
 
-    internal var getScrollView: () -> UIScrollView
+    internal var getScrollView: () -> UIScrollView?
     internal var getRectOfContent: (_ id: Int) -> CGRect?
     internal var performScrollToPoint: (_ point: CGPoint, _ animated: Bool) -> Void
     internal var performScrollToId: (_ id: Int, _ anchor: UnitPoint, _ animated: Bool) -> Void
     internal var performScrollToIdIfNeeded: (_ id: Int, _ anchor: UnitPoint) -> Void
 
     /// Returns the UIScrollView
-    public var scrollView: UIScrollView { getScrollView() }
+    public var scrollView: UIScrollView? { getScrollView() }
     /// returns the content's CGRect
     public func rectOfContent<ID: Hashable>(id: ID) -> CGRect? { getRectOfContent(id.hashValue) }
     /// performs a scroll to a specific `CGPoint`
@@ -31,7 +31,7 @@ public struct LegacyScrollViewProxy {
 extension LegacyScrollViewReader {
     func makeProxy(with view: LegacyUIScrollViewReader) -> LegacyScrollViewProxy {
         LegacyScrollViewProxy {
-            view.scrollView!
+            view.scrollView
         } getRectOfContent: { id in
             getRectOfContent(with: id, in: view)
         } performScrollToPoint: { point, animated in

--- a/Sources/LegacyScrollView/Proxy/LegacyScrollViewReader.swift
+++ b/Sources/LegacyScrollView/Proxy/LegacyScrollViewReader.swift
@@ -22,6 +22,10 @@ public struct LegacyScrollViewReader<Content: View>: UIViewRepresentable {
     }
 
     public func updateUIView(_ view: LegacyUIScrollViewReader, context: Context) {
+        guard let _ = view.scrollView else {
+            //Warning: updateUIView called before view was added to view hierarchy
+            return
+        }
         let proxy = makeProxy(with: view)
         let contentView = content(proxy)
 


### PR DESCRIPTION
It's better to check if the scrollView is not nil in updateUIView function before makeProxy, and not to force unwrap the scrollView to prevent potential crash.